### PR TITLE
Throws exceptions on mixed data type arrays

### DIFF
--- a/tests/extended.toml
+++ b/tests/extended.toml
@@ -31,7 +31,9 @@ data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers supp
 
 # Multi-line array check
 key = [
+  [
   1, 2, 3,
+  ],
   [
     1979-05-27T07:32:00Z,
     1979-05-27T07:32:00Z


### PR DESCRIPTION
Modified the parser so as to throw an exception on encountering mixed
data types within an array. Also corrected the extended.toml to prevent
from throwing this exception because of malformed key "key"
